### PR TITLE
Made change so a table won't compress, it will stay the correct width.

### DIFF
--- a/jquery.sticky-div.js
+++ b/jquery.sticky-div.js
@@ -35,6 +35,7 @@
     var window_top = $(window).scrollTop();
     var window_height = $(window).height();
     selector.each(function () {
+      $(this).width($(this).width());
       var div_top = $(this).prev().offset().top;
       var div_height = $(this).outerHeight();
       if ((!options.outer_div || (div_height < $(options.outer_div).height())) && (window_top > (div_top - options.top)) && (div_height < (window_height - options.bottom))) {


### PR DESCRIPTION
Before if there was a table, it would compress the table's width. Now it will stay the correct width. I didn't test this with other implementations of this plugin.
