### PR TITLE
Several improvements to the plugin :)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,21 +33,21 @@ Sample usage:
 Options:
 ---------
 
- - `top` (default: `0px`)
+ - `top` (default: `0px`)<br/>
 This represents the buffer you want between the top of the page and the `div` in pixels.
 
-- `min_screen_width` (default: `0px`)
+- `min_screen_width` (default: `0px`)<br/>
 This represents the minimum screen width that the stickiness will be applied at.
 
-- `min_screen_height` (default: `0px`)
+- `min_screen_height` (default: `0px`)<br/>
 This represents the minimum screen height that the stickiness will be applied at.
 
-- `bottom` (default: `0px`)
+- `bottom` (default: `0px`)<br/>
 This represents the buffer you want between the bottom of the page and the `div` in pixels.
 
-- `outer_div` (default: `null`)
+- `outer_div` (default: `null`)<br/>
 This is a jQuery or DOM element whose height needs to be greater than the `div` in order to make it sticky.
 
-- `style_css` (default: `null`)
+- `style_css` (default: `null`)<br/>
 This is an optional setting that allows you to specify a CSS class to extend the styles applied to the sticky `div`.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 sticky-div
 ==========
 
-A jQuery plugin that forces a `div` to stick to the top of the viewport if the user scrolls past it.
+A jQuery plugin that forces a `div` to stick to the top or bottom of the viewport if the user scrolls past it.
 
 Inspired by the blog post _["Stick div at top after scrolling"](http://blog.yjl.im/2010/01/stick-div-at-top-after-scrolling.html)_ by **YJL**.
 
@@ -25,6 +25,7 @@ Sample usage:
       min_screen_width: 0,
       min_screen_height: 0,
       bottom: 0,
+      stick_bottom: false,
       outer_div: null,
       style_css: null
     };
@@ -44,6 +45,9 @@ This represents the minimum screen height that the stickiness will be applied at
 
 - `bottom` (default: `0px`)<br/>
 This represents the buffer you want between the bottom of the page and the `div` in pixels.
+
+- `stick_bottom` (default: `false`)<br/>
+This is a boolean value (`true`/`false`) to indicate if the sticky div sticks to the bottom of the viewport.
 
 - `outer_div` (default: `null`)<br/>
 This is a jQuery or DOM element whose height needs to be greater than the `div` in order to make it sticky.

--- a/README.md
+++ b/README.md
@@ -1,26 +1,49 @@
 sticky-div
 ==========
 
-A jquery plugin that forces a div to stick to the top of the window if the user tries to scroll past it.
+A jQuery plugin that forces a `div` to stick to the top of the viewport if the user scrolls past it.
 
-Inspired by the following blog post: http://blog.yjl.im/2010/01/stick-div-at-top-after-scrolling.html
+Inspired by the blog post _["Stick div at top after scrolling"](http://blog.yjl.im/2010/01/stick-div-at-top-after-scrolling.html)_ by **YJL**.
 
 Sample usage:
+----------------
 
-In your html:
+**HTML:**
 
     <div id="my_div">
       ...
     </div>
 
-In your javascript:
+**JavaScript:**
+
+    $('#my_div').sticky_div();
+
+    // Or:
 
     var options = {
-      top: 0, // This represents the buffer you want between the top of the page and the div in px. Default is 0.
-      min_screen_width: 0, // This represents the minimum screen width that the stickiness will be applied to. Default is 0.
-      bottom: 0, // This represents the buffer you want between the bottom of the page and the div in px. Default is 0.
-      outer_div: null, // This is a jquery or DOM element whose height needs to be greater than the div in order to make it sticky. Default is null.
-      style_css: null // This is an optional setting that allows you to specify a css class to extend the styles applied to the sticky div. Default is null.
+      top: 0,
+      min_screen_width: 0,
+      bottom: 0,
+      outer_div: null,
+      style_css: null
     };
-    $('#my_div').sticky_div(options); // Or just $('#my_div').sticky_div();
+    $('#my_div').sticky_div(options);
+
+Options:
+---------
+
+ - `top` (default: `0px`)
+This represents the buffer you want between the top of the page and the `div` in pixels.
+
+- `min_screen_width` (default: `0px`)
+This represents the minimum screen width that the stickiness will be applied at.
+
+- `bottom` (default: `0px`)
+This represents the buffer you want between the bottom of the page and the `div` in pixels.
+
+- `outer_div` (default: `null`)
+This is a jQuery or DOM element whose height needs to be greater than the `div` in order to make it sticky.
+
+- `style_css` (default: `null`)
+This is an optional setting that allows you to specify a CSS class to extend the styles applied to the sticky `div`.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ In your javascript:
       top: 0, // This represents the buffer you want between the top of the page and the div in px. Default is 0.
       min_screen_width: 0, // This represents the minimum screen width that the stickiness will be applied to. Default is 0.
       bottom: 0, // This represents the buffer you want between the bottom of the page and the div in px. Default is 0.
-      outer_div: null // This is a jquery or DOM element whose height needs to be greater than the div in order to make it sticky. Default is null.
+      outer_div: null, // This is a jquery or DOM element whose height needs to be greater than the div in order to make it sticky. Default is null.
+      style_css: null // This is an optional setting that allows you to specify a css class to extend the styles applied to the sticky div. Default is null.
     };
     $('#my_div').sticky_div(options); // Or just $('#my_div').sticky_div();
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Sample usage:
     var options = {
       top: 0,
       min_screen_width: 0,
+      min_screen_height: 0,
       bottom: 0,
       outer_div: null,
       style_css: null
@@ -37,6 +38,9 @@ This represents the buffer you want between the top of the page and the `div` in
 
 - `min_screen_width` (default: `0px`)
 This represents the minimum screen width that the stickiness will be applied at.
+
+- `min_screen_height` (default: `0px`)
+This represents the minimum screen height that the stickiness will be applied at.
 
 - `bottom` (default: `0px`)
 This represents the buffer you want between the bottom of the page and the `div` in pixels.

--- a/jquery.sticky-div.js
+++ b/jquery.sticky-div.js
@@ -3,6 +3,7 @@
     var defaults = {
       top: 0,
       min_screen_width: 0,
+      min_screen_height: 0,
       bottom: 0,
       outer_div: null,
       style_css: null
@@ -43,6 +44,7 @@
       bool_sticky_div = bool_sticky_div && (window_top > (div_top - options.top));
       bool_sticky_div = bool_sticky_div && (div_height < (window_height - options.bottom));
       bool_sticky_div = bool_sticky_div && ($(window).width() >= options.min_screen_width);
+      bool_sticky_div = bool_sticky_div && ($(window).height() >= options.min_screen_height);
       
       if (bool_sticky_div) {
         $(this).addClass('sticky-div');

--- a/jquery.sticky-div.js
+++ b/jquery.sticky-div.js
@@ -4,7 +4,8 @@
       top: 0,
       min_screen_width: 0,
       bottom: 0,
-      outer_div: null
+      outer_div: null,
+      style_css: null
     };
     var options = $.extend(defaults, options);
 
@@ -40,9 +41,15 @@
       var div_height = $(this).outerHeight();
       if ((!options.outer_div || (div_height < $(options.outer_div).height())) && (window_top > (div_top - options.top)) && (div_height < (window_height - options.bottom))) {
         $(this).addClass('sticky-div');
+        if (options.style_css != null) {
+          $(this).addClass(options.style_css);
+        }
       } else {
         $(this).removeClass('sticky-div');
+        if (options.style_css != null) {
+          $(this).removeClass(options.style_css);
+        }
       }
     });
-  }
+  };
 })(jQuery);

--- a/jquery.sticky-div.js
+++ b/jquery.sticky-div.js
@@ -17,7 +17,7 @@
     
     // add a class to the anchor, and check for it, so that the anchor <div/> is only added the once.
     selector.each(function () {
-      if (!$(this).prev().hasClass(".sticky-anchor")) {
+      if (!$(this).prev().hasClass("sticky-anchor")) {
         $(this).before("<div class='sticky-anchor'></div>");
       }
     });

--- a/jquery.sticky-div.js
+++ b/jquery.sticky-div.js
@@ -22,12 +22,15 @@
       }
     });
 
-    // call to main method, so that it is not only a window scroll which triggers it
-    $.sticky_div(selector, options);
-    $(window).scroll(function () {
-      // called again on scroll.
+    var call_sticky_div = function() {
       $.sticky_div(selector, options);
-    });
+    };
+    // call to main method, so that it is not only a window scroll which triggers it
+    call_sticky_div();
+    // called again on scroll
+    $(window).scroll(call_sticky_div);
+    // called again on resize
+    $(window).resize(call_sticky_div);
   };
 
   // main method, which does the magic

--- a/jquery.sticky-div.js
+++ b/jquery.sticky-div.js
@@ -33,6 +33,7 @@
   // main method, which does the magic
   $.sticky_div = function (selector, options) {
     var window_top = $(window).scrollTop();
+    var window_width = $(window).width();
     var window_height = $(window).height();
     
     selector.each(function () {
@@ -43,8 +44,8 @@
       var bool_sticky_div = (!options.outer_div || (div_height < $(options.outer_div).height()));
       bool_sticky_div = bool_sticky_div && (window_top > (div_top - options.top));
       bool_sticky_div = bool_sticky_div && (div_height < (window_height - options.bottom));
-      bool_sticky_div = bool_sticky_div && ($(window).width() >= options.min_screen_width);
-      bool_sticky_div = bool_sticky_div && ($(window).height() >= options.min_screen_height);
+      bool_sticky_div = bool_sticky_div && (window_width >= options.min_screen_width);
+      bool_sticky_div = bool_sticky_div && (window_height >= options.min_screen_height);
       
       if (bool_sticky_div) {
         $(this).addClass('sticky-div');

--- a/jquery.sticky-div.js
+++ b/jquery.sticky-div.js
@@ -25,8 +25,8 @@
     var call_sticky_div = function() {
       $.sticky_div(selector, options);
     };
-    // call to main method, so that it is not only a window scroll which triggers it
-    call_sticky_div();
+    // call main method when DOM is ready
+    $(document).ready(call_sticky_div);
     // called again on scroll
     $(window).scroll(call_sticky_div);
     // called again on resize

--- a/jquery.sticky-div.js
+++ b/jquery.sticky-div.js
@@ -41,7 +41,8 @@
     
     selector.each(function () {
       $(this).width($(this).width());
-      var div_top = $(this).prev().offset().top;
+      var anchor = $(this).prev();
+      var div_top = anchor.offset().top;
       var div_height = $(this).outerHeight();
       
       var bool_sticky_div = (!options.outer_div || (div_height < $(options.outer_div).height()));
@@ -55,11 +56,13 @@
         if (options.style_css != null) {
           $(this).addClass(options.style_css);
         }
+        anchor.height(div_height);
       } else {
         $(this).removeClass('sticky-div');
         if (options.style_css != null) {
           $(this).removeClass(options.style_css);
         }
+        anchor.height(0);
       }
     });
   };

--- a/jquery.sticky-div.js
+++ b/jquery.sticky-div.js
@@ -24,10 +24,8 @@
     // call to main method, so that it is not only a window scroll which triggers it
     $.sticky_div(selector, options);
     $(window).scroll(function () {
-      if ($(window).width() >= options.min_screen_width) {
-        // called again on scroll.
-        $.sticky_div(selector, options);
-      }
+      // called again on scroll.
+      $.sticky_div(selector, options);
     });
   };
 
@@ -44,6 +42,7 @@
       var bool_sticky_div = (!options.outer_div || (div_height < $(options.outer_div).height()));
       bool_sticky_div = bool_sticky_div && (window_top > (div_top - options.top));
       bool_sticky_div = bool_sticky_div && (div_height < (window_height - options.bottom));
+      bool_sticky_div = bool_sticky_div && ($(window).width() >= options.min_screen_width);
       
       if (bool_sticky_div) {
         $(this).addClass('sticky-div');

--- a/jquery.sticky-div.js
+++ b/jquery.sticky-div.js
@@ -35,11 +35,17 @@
   $.sticky_div = function (selector, options) {
     var window_top = $(window).scrollTop();
     var window_height = $(window).height();
+    
     selector.each(function () {
       $(this).width($(this).width());
       var div_top = $(this).prev().offset().top;
       var div_height = $(this).outerHeight();
-      if ((!options.outer_div || (div_height < $(options.outer_div).height())) && (window_top > (div_top - options.top)) && (div_height < (window_height - options.bottom))) {
+      
+      var bool_sticky_div = (!options.outer_div || (div_height < $(options.outer_div).height()));
+      bool_sticky_div = bool_sticky_div && (window_top > (div_top - options.top));
+      bool_sticky_div = bool_sticky_div && (div_height < (window_height - options.bottom));
+      
+      if (bool_sticky_div) {
         $(this).addClass('sticky-div');
         if (options.style_css != null) {
           $(this).addClass(options.style_css);

--- a/jquery.sticky-div.js
+++ b/jquery.sticky-div.js
@@ -5,13 +5,18 @@
       min_screen_width: 0,
       min_screen_height: 0,
       bottom: 0,
+      stick_bottom: false,
       outer_div: null,
       style_css: null
     };
     var options = $.extend(defaults, options);
 
-    // !important to override any current positioning or top.
-    $("<style type='text/css'> .sticky-div{ position:fixed !important; top:" + options.top + "px !important;} </style>").appendTo("head");
+    // !important to override any current positioning or top/bottom.
+    $("<style type='text/css'>"
+      + " .sticky-div-top    { position: fixed !important; top: "    + options.top    + "px !important; }"
+      + " .sticky-div-bottom { position: fixed !important; bottom: " + options.bottom + "px !important; }"
+      + " </style>")
+      .appendTo("head");
 
     var selector = this;
     
@@ -46,19 +51,32 @@
       var div_height = $(this).outerHeight();
       
       var bool_sticky_div = (!options.outer_div || (div_height < $(options.outer_div).height()));
-      bool_sticky_div = bool_sticky_div && (window_top > (div_top - options.top));
-      bool_sticky_div = bool_sticky_div && (div_height < (window_height - options.bottom));
       bool_sticky_div = bool_sticky_div && (window_width >= options.min_screen_width);
       bool_sticky_div = bool_sticky_div && (window_height >= options.min_screen_height);
+      if (options.stick_bottom) {
+        bool_sticky_div = bool_sticky_div && ((window_top + window_height) < ((div_top + div_height) + options.bottom));
+        bool_sticky_div = bool_sticky_div && (div_height < (window_height - options.top));
+      } else {
+        bool_sticky_div = bool_sticky_div && (window_top > (div_top - options.top));
+        bool_sticky_div = bool_sticky_div && (div_height < (window_height - options.bottom));
+      }
       
       if (bool_sticky_div) {
-        $(this).addClass('sticky-div');
+        if (options.stick_bottom) {
+          $(this).addClass('sticky-div-bottom');
+        } else {
+          $(this).addClass('sticky-div-top');
+        }
         if (options.style_css != null) {
           $(this).addClass(options.style_css);
         }
         anchor.height(div_height);
       } else {
-        $(this).removeClass('sticky-div');
+        if (options.stick_bottom) {
+          $(this).removeClass('sticky-div-bottom');
+        } else {
+          $(this).removeClass('sticky-div-top');
+        }
         if (options.style_css != null) {
           $(this).removeClass(options.style_css);
         }


### PR DESCRIPTION
I've made several improvements. Please see the full commit list and individual commit change in the Commits tab. To summarize:

- Added an option to support extended styles. (Author: tater9104)\*
- Prettify and reformat the README file
- Refactor the lengthy if condition into multiple lines (same effect, cleaner code)
- Always call the method when resizing. Method to check minimum width.
- Add new option for minimum screen height
- Store and use window width/height from variables
- Add the new option min_screen_height in the README file
- Use a common function and call it for both scroll and resize (so that resizing can also stick/unstick the sticky)

\* Committer Notes for commit 5628100: Changes from the fork repo tater9104/sticky-div were
ported here without altering the indentation of the original source. I think this enhances the plugin by being able to apply custom styles on the div when it sticks (like giving it a shadow or a different background color).